### PR TITLE
Fix/user: swagger 재설정, constant 수정

### DIFF
--- a/src/commons/constants/users/user-message.constant.ts
+++ b/src/commons/constants/users/user-message.constant.ts
@@ -17,9 +17,9 @@ export const USER_MESSAGES = {
             CONFLICT: '이미 다른 회원이 사용 중인 닉네임 입니다.',
           },
           PASSWORD: {
+            EMPTY: '비밀번호를 입력해 주세요.',
             NOW: '현재 비밀번호를 입력해 주세요.',
-            CHANGE: '변경할 비밀번호를 입력해 주세요.',
-            WEAK: '비밀번호 규칙이 올바르지 않습니다.',
+            WEAK: '비밀번호는 최소 8자리 이상, 특수 문자 1개 이상의 영문 조합으로 입력해 주세요.',
             MISMATCH: '현재 비밀번호가 일치하지 않습니다.',
           },
           PROFILEIMG: {

--- a/src/commons/constants/users/user.constant.ts
+++ b/src/commons/constants/users/user.constant.ts
@@ -1,1 +1,9 @@
-export const USER_CONSTANT = {};
+export const USER_CONSTANT = {
+  PASSWORD: {
+    MIN_LENGTH: 8,
+    MIN_SYMBOLS: 1,
+  },
+  POINT: {
+    DEFAULT: 1000000,
+  },
+};

--- a/src/entities/users/user.entity.ts
+++ b/src/entities/users/user.entity.ts
@@ -14,23 +14,43 @@ import { Bookmark } from './bookmark.entity';
 import { Show } from '../shows/show.entity';
 import { Ticket } from '../shows/ticket.entity';
 import { Trade } from '../trades/trade.entity';
+import { USER_CONSTANT } from 'src/commons/constants/users/user.constant';
+import { USER_MESSAGES } from 'src/commons/constants/users/user-message.constant';
 
 @Entity('users')
 export class User {
   @PrimaryGeneratedColumn({ unsigned: true })
   id: number;
 
-  @IsNotEmpty({ message: '이메일을 입력해 주세요.' })
+  /**
+   * 이메일
+   * @example "modify@sample.com"
+   */
+  @IsNotEmpty({ message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.EMAIL.EMPTY })
   @IsEmail()
   @Column({ unique: true })
   email: string;
 
-  @IsNotEmpty({ message: '닉네임을 입력해 주세요.' })
+  /**
+   * 닉네임
+   * @example "Charlie"
+   */
+  @IsNotEmpty({ message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.NICKNAME.EMPTY })
   @Column({ unique: true })
   nickname: string;
 
-  @IsNotEmpty({ message: '비밀번호를 입력해 주세요.' })
-  @IsStrongPassword({ minLength: 8, minSymbols: 1 }, {})
+  /**
+   * 비밀번호
+   * @example "Test1234!"
+   */
+  @IsNotEmpty({ message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.PASSWORD.EMPTY })
+  @IsStrongPassword(
+    {
+      minLength: USER_CONSTANT.PASSWORD.MIN_LENGTH,
+      minSymbols: USER_CONSTANT.PASSWORD.MIN_SYMBOLS,
+    },
+    { message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.PASSWORD.WEAK }
+  )
   @Column({ select: false })
   password: string;
 
@@ -38,9 +58,13 @@ export class User {
   refreshToken: string;
 
   @IsNotEmpty()
-  @Column({ default: 1000000 })
+  @Column({ default: USER_CONSTANT.POINT.DEFAULT })
   point: number;
 
+  /**
+   * 프로필 이미지
+   * @example "https://example.com/profile.jpg"
+   */
   @Column()
   profileImg: string;
 

--- a/src/modules/users/dto/charge-point.dto.ts
+++ b/src/modules/users/dto/charge-point.dto.ts
@@ -2,6 +2,10 @@ import { IsNotEmpty, IsNumber, IsPositive } from 'class-validator';
 import { USER_MESSAGES } from 'src/commons/constants/users/user-message.constant';
 
 export class ChargePointDto {
+  /**
+   * 포인트
+   * @example 10000
+   */
   @IsNumber()
   @IsPositive({
     message: USER_MESSAGES.USER.POINT_CHARGE.FAILURE.POSITIVE,

--- a/src/modules/users/dto/user-update.dto.ts
+++ b/src/modules/users/dto/user-update.dto.ts
@@ -1,35 +1,16 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { PickType } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { User } from 'src/entities/users/user.entity';
 import { USER_MESSAGES } from 'src/commons/constants/users/user-message.constant';
 
-export class UserUpdateDto {
-  /**
-   * 닉네임
-   * @example 'Charlie'
-   */
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty({
-    message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.NICKNAME.EMPTY,
-  })
-  nickname: string;
-
+export class UserUpdateDto extends PickType(User, ['nickname', 'profileImg']) {
   /**
    * 현재 비밀번호
-   * @example 'Aaaa!111'
+   * @example "Test1234!"
    */
   @IsString()
   @IsNotEmpty({
     message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.PASSWORD.NOW,
   })
   currentPassword: string;
-
-  /**
-   * 프로필 이미지
-   * @example ''
-   */
-  @IsString()
-  @IsNotEmpty({
-    message: USER_MESSAGES.USER.USERINFO.UPDATE.FAILURE.PROFILEIMG.EMPTY,
-  })
-  profileImg: string;
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -15,7 +15,11 @@ import { UsersService } from './users.service';
 import { UserUpdateDto } from './dto/user-update.dto';
 import { ChargePointDto } from './dto/charge-point.dto';
 import { USER_MESSAGES } from 'src/commons/constants/users/user-message.constant';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
+@UseGuards(AuthGuard('jwt'))
+@ApiTags('사용자')
+@ApiBearerAuth()
 @Controller('users')
 export class UsersController {
   constructor(private readonly userService: UsersService) {}
@@ -50,7 +54,6 @@ export class UsersController {
    * @param userUpdateDto
    * @returns
    */
-  @UseGuards(AuthGuard('jwt'))
   @Patch('/me')
   async updateUser(@Req() req: any, @Body() userUpdateDto: UserUpdateDto) {
     const updateUser = await this.userService.updateUser(req.user.id, userUpdateDto);
@@ -68,7 +71,6 @@ export class UsersController {
    * @param chargePointDto
    * @returns
    */
-  @UseGuards(AuthGuard('jwt'))
   @Post('/me/point')
   async chargePoint(@Req() req: any, @Body() chargePointDto: ChargePointDto) {
     const updateUserPoint = await this.userService.chargePoint(req.user.id, chargePointDto);
@@ -85,7 +87,6 @@ export class UsersController {
    * @param req
    * @returns
    */
-  @UseGuards(AuthGuard('jwt'))
   @Delete('/me')
   async deleteUser(@Req() req: any) {
     const deleteUser = await this.userService.deleteUser(req.user.id);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -52,7 +52,10 @@ export class UsersService {
     const { nickname, profileImg, currentPassword } = userUpdateDto;
 
     // 사용자 조회
-    const user = await this.userRepository.findOneBy({ id });
+    const user = await this.userRepository.findOne({
+      where: { id },
+      select: ['id', 'nickname', 'password', 'profileImg'],
+    });
 
     if (!user) {
       throw new NotFoundException(USER_MESSAGES.USER.COMMON.NOT_FOUND);


### PR DESCRIPTION
**_피드백 반영_** + 수정
- PickType으로 entity에서 dto 가져오는 형태로 user-update.dto 수정
- dto 파일이 아닌 entity에서 email, nickname, password, profileImg, amount(포인트)에 Swagger 재설정
- 비밀번호 조건 메세지 추가
- 메시지 상수화
- @ApiBearerAuth() 적용

swagger에서 동작 테스트 완료 (사용자 정보 수정, 사용자 포인트 충전, 회원 탈퇴)