### PR TITLE
fix/create ticket

### DIFF
--- a/src/modules/shows/dto/create-ticket-dto.ts
+++ b/src/modules/shows/dto/create-ticket-dto.ts
@@ -1,0 +1,8 @@
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class CreateTicketDto {
+  @Type(() => Number)
+  @IsNumber()
+  scheduleId: number;
+}

--- a/src/modules/shows/shows.controller.ts
+++ b/src/modules/shows/shows.controller.ts
@@ -22,6 +22,7 @@ import { DeleteBookmarkDto } from './dto/delete-bookmark.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UpdateShowDto } from './dto/update-show.dto';
 import { GetShowListDto } from './dto/get-show-list.dto';
+import { CreateTicketDto } from './dto/create-ticket-dto';
 
 @ApiTags('공연')
 @Controller('shows')
@@ -126,9 +127,14 @@ export class ShowsController {
   @Post(':showId/ticket')
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(AuthGuard('jwt'))
-  async createTicket(@Param('showId') showId: number, scheduleId: number, @Req() req: any) {
+  async createTicket(
+    @Param('showId') showId: number,
+    scheduleId: number,
+    @Body() createTicketDto: CreateTicketDto,
+    @Req() req: any
+  ) {
     const user: User = req.user;
-    return this.showsService.createTicket(showId, scheduleId, user);
+    return this.showsService.createTicket(showId, createTicketDto, scheduleId, user);
   }
   /**
    * 티켓 환불


### PR DESCRIPTION
1. create ticket dto 파일 추가했습니다 - 사유: 같은 공연이라도 스케줄이 여러 개 겹칠 수 있기 때문에 스케줄 아이디를 body에 입력받는 형식을 구현하였습니다.
2. 티켓 예매할 때 공연시간 관련 로직에서 공연 날짜와 시간을 하나의 공연시간으로 인식할 수 있도록 수정하였습니다.