### PR TITLE
Bugfix/kakao social sign in http method

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
    * @returns
    */
   @UseGuards(KakaoAuthGuard)
-  @Post('/kakao')
+  @Get('/kakao')
   async kakaoSignIn(@Req() req: any, @Res() res: any) {
     console.log('controller : ', req.user);
     const { accessToken, refreshToken } = await this.authService.signIn(req.user);


### PR DESCRIPTION
- 카카오 소셜 로그인 Http 메서드 변경
- Post -> Get
- 생각해보니 웹브라우저에서의 페이지 이동은 기본적으로 Get 메서드 사용