### PR TITLE
Bugfix/공연 상세페이지에서 수정, 삭제버튼 관리자만 보이게 수정

### DIFF
--- a/src/public/js/common/header.js
+++ b/src/public/js/common/header.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const token = window.localStorage.getItem('accessToken');
 
     // 포인트 조회를 통해서 토큰이 유효한지 확인
-    const response = await axios.get('/users/me/point', {
+    const response = await axios.get('/users/me', {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/public/js/shows/shows-detail.js
+++ b/src/public/js/shows/shows-detail.js
@@ -174,7 +174,6 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
-  // admin에게만 삭제 버튼이 보이게 하는 로직
   async function checkUserRoleAndDisplayDeleteButton() {
     try {
       if (token) {
@@ -184,9 +183,9 @@ document.addEventListener('DOMContentLoaded', function () {
           },
         });
 
-        const userRole = userResponse.data.role; // 사용자 역할 정보
+        const userRole = userResponse.data.getUserProfile.role; // 사용자 역할 정보
 
-        if (userRole === userResponse.data.role.ADMIN) {
+        if (userRole === 'ADMIN') {
           // 관리자일 경우 버튼 표시
           deleteBtn.style.display = 'block';
           updateBtn.style.display = 'block';
@@ -204,12 +203,13 @@ document.addEventListener('DOMContentLoaded', function () {
       console.error('사용자 권한 확인 오류:', err);
       // 권한 확인 오류 발생 시 버튼 숨기기
       deleteBtn.style.display = 'none';
+      updateBtn.style.display = 'none';
     }
   }
 
+  checkUserRoleAndDisplayDeleteButton();
   // 삭제 버튼 클릭 이벤트 핸들러
   deleteBtn.addEventListener('click', async function () {
-    checkUserRoleAndDisplayDeleteButton();
     try {
       const response = await axios({
         method: 'delete',

--- a/src/views/shows/shows-detail.view.ejs
+++ b/src/views/shows/shows-detail.view.ejs
@@ -91,11 +91,6 @@
           <button class="booking__btn btn btn-primary">Go Booking</button>
         </form>
 
-        <!-- separator -->
-        <div class="separator">
-          <p>OR</p>
-        </div>
-
         <!-- update button -->
         <button class="update__btn btn btn-warning">Update</button>
 
@@ -106,10 +101,6 @@
 
         <!-- back button -->
         <button class="back__btn btn btn-secondary">Back</button>
-
-        <div class="separator">
-          <p>OR</p>
-        </div>
 
         <!-- delete button -->
         <button class="delete__btn btn btn-info">Delete</button>


### PR DESCRIPTION
1. header.js에서 /users/me랑 통신하게 해서 관리자로 로그인하는 경우 내정보, 로그아웃이 보이도록 수정했습니다.
2.  공연 상세페이지에 admin으로만 접속할 때 수정, 삭제버튼이 보이도록 했습니다.(로그인하지 않은 사용자, user는 수정. 삭제버튼을 보지 못합니다.)
