### PR TITLE
Bugfix/kakao sign in redirect url

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -5,7 +5,6 @@ import { SignInDto } from './dto/sign-in.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { KakaoAuthGuard } from './utils/kakao.guard';
-import { HOST_NAME } from 'src/commons/constants/auth/auth.constant';
 
 @ApiTags('인증')
 @Controller('auth')
@@ -43,7 +42,7 @@ export class AuthController {
   async kakaoSignIn(@Req() req: any, @Res() res: any) {
     const { accessToken, refreshToken } = await this.authService.signIn(req.user);
     res.redirect(
-      `${HOST_NAME}/views/auth/kakao/process?accessToken=${accessToken}&refreshToken=${refreshToken}`
+      `${process.env.HOST_NAME}/views/auth/kakao/process?accessToken=${accessToken}&refreshToken=${refreshToken}`
     );
   }
 


### PR DESCRIPTION
- 카카오 로그인 리다이렉트 주소 설정 완료
- Github Actions Secret 변경
- 서버에서는 mymycode.shop 형태로 사용
- 로컬에서는 localhost:3000으로 사용