### PR TITLE
Fix/피드백에 기반한 공연 상세페이지 수정

### DIFF
--- a/src/public/js/shows/shows-detail.js
+++ b/src/public/js/shows/shows-detail.js
@@ -70,21 +70,34 @@ document.addEventListener('DOMContentLoaded', function () {
         `;
 
         if (data.schedules && data.schedules.length > 0) {
-          scheduleDropdownMenu.innerHTML = data.schedules
-            .map(
-              (schedule) => `
-              <li>
-                <a class="dropdown-item" href="#" data-schedule-id="${schedule.id}">
-                  날짜 : ${schedule.date} | 시간 : ${schedule.time} | 잔여좌석 : ${schedule.remainSeat}
-                </a>
-              </li>
-            `
-            )
-            .join('');
+          const now = new Date();
+
+          // 잔여좌석이 0이 아니고, 현재 시간 이후의 스케줄만 필터링
+          const filteredSchedules = data.schedules.filter((schedule) => {
+            const scheduleDateTime = new Date(`${schedule.date} ${schedule.time}`);
+            return schedule.remainSeat > 0 && scheduleDateTime > now;
+          });
+
+          if (filteredSchedules.length > 0) {
+            scheduleDropdownMenu.innerHTML = filteredSchedules
+              .map(
+                (schedule) => `
+            <li>
+              <a class="dropdown-item" href="#" data-schedule-id="${schedule.id}">
+                날짜 : ${schedule.date} | 시간 : ${schedule.time} | 잔여좌석 : ${schedule.remainSeat}
+              </a>
+            </li>
+          `
+              )
+              .join('');
+          } else {
+            scheduleDropdownMenu.innerHTML =
+              '<li><a class="dropdown-item">공연 일정이 지났거나 유효한 일정 정보가 없습니다.</a></li>';
+          }
 
           // 저장된 스케줄 ID가 있는 경우 버튼 텍스트 업데이트
           if (window.selectedScheduleId) {
-            const selectedSchedule = data.schedules.find(
+            const selectedSchedule = filteredSchedules.find(
               (schedule) => schedule.id === window.selectedScheduleId
             );
             if (selectedSchedule) {
@@ -142,7 +155,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   backBtn.addEventListener('click', function (e) {
     e.preventDefault();
-    window.location.href = `/views/shows/list`;
+
+    // 기존 페이지로 이동
+    window.history.back();
   });
 
   scheduleDropdownMenu.addEventListener('click', function (e) {
@@ -188,6 +203,12 @@ document.addEventListener('DOMContentLoaded', function () {
         ? `/shows/${showId}/bookmark/${bookmarkId}`
         : `/shows/${showId}/bookmark`;
 
+      if (!token) {
+        alert('로그인이 필요합니다');
+        window.location.href = '/views/auth/sign';
+        return;
+      }
+
       const response = await axios({
         method: method,
         url: url,
@@ -195,17 +216,14 @@ document.addEventListener('DOMContentLoaded', function () {
           Authorization: `Bearer ${token}`,
         },
       });
-      console.log(bookmarkId);
+
       if (response.status === 200 || response.status === 201) {
         isBookmarked = !isBookmarked;
         bookmarkId = isBookmarked ? response.data.bookmarkId : null; // 찜하기 성공 시 서버에서 bookmarkId를 반환한다고 가정합니다.
         updateBookmarkButton();
         alert(isBookmarked ? '찜하기가 완료되었습니다.' : '찜하기가 취소되었습니다.');
-      } else {
-        alert('요청에 실패하였습니다. 응답 상태 코드: ' + response.status);
       }
     } catch (error) {
-      console.error('찜하기 오류:', error);
       alert('요청에 실패하였습니다.');
     }
   });

--- a/src/public/js/shows/shows-ticket.js
+++ b/src/public/js/shows/shows-ticket.js
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', function () {
     } catch (err) {
       if (err.response && err.response.data) {
         alert(err.response.data.message);
-        window.location.href = `/views/me`;
+        window.location.href = `/views/shows/${showId}`;
       } else {
         console.error('Error:', err);
         alert('서버와의 통신 중 오류가 발생하였습니다.');


### PR DESCRIPTION
1. 상세보기 페이지에서 뒤로가기를 누르면 기존에 있던 페이지로 이동하도록 수정
2. 공연 예매 가능한 시간이 아닌 시간을 선택하여 결제 시도 시 404 notfound 에러페이지로 넘어가는 버그 수정 후 이전에 보고 있던 공연 페이지로 리다이렉팅하게 수정
3. 예매 불가능한 시간대의 공연(주로 공연 일정이 현재 시간보다 과거일 경우) 및 잔여 좌석이 0인 경우 선택 항목에서 보이지 않도록 설정