### PR TITLE
Update/showList - redis cache

### DIFF
--- a/src/modules/shows/shows.service.ts
+++ b/src/modules/shows/shows.service.ts
@@ -157,7 +157,7 @@ export class ShowsService {
     // 2. search 없는 경우
     // 2-1. 캐시에서 조회
     const cacheKey = `showList:${category}:${page}:${limit}`;
-    const cachedData = await this.cacheManager.get(cacheKey);
+    const cachedData = await this.redisClient.get(cacheKey);
 
     if (cachedData) {
       return cachedData;
@@ -194,7 +194,7 @@ export class ShowsService {
       totalPages: Math.ceil(total / limit),
     };
 
-    await this.cacheManager.set(cacheKey, response, 300);
+    await this.redisClient.set(cacheKey, JSON.stringify(response), 'EX', 300);
 
     return response;
   }


### PR DESCRIPTION
공연 목록 조회 캐싱 적용
- `cache manager` > `redis client`로 수정

- redis에 데이터 존재하지 않을 때 (캐싱 O)
![JMeter - redis에 데이터 존재하지 않을 때(redis캐싱)](https://github.com/user-attachments/assets/3cd0807b-d465-4dce-be65-3838a5660752)

- db에서 직접 가져올 때 (캐싱 X)
![JMeter - db에서 직접 가져올 때](https://github.com/user-attachments/assets/a554f369-68ff-4d3f-b893-a988c659b090)
